### PR TITLE
add direction attribute selector to override style in rtl mode

### DIFF
--- a/src/components/feed/Player/PlayerControls/PlayerControls.css
+++ b/src/components/feed/Player/PlayerControls/PlayerControls.css
@@ -1,7 +1,7 @@
 .player-buttons {
   position: absolute;
   right: 0;
-  margin-right: 1rem;
+  margin-inline-end: 1rem;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -13,6 +13,11 @@
   transform: translateZ(0);
   -webkit-transform: translateZ(0);
   -webkit-transform: translate3d(0, 0, 0);
+}
+
+[dir='rtl'] .player-buttons {
+  right: unset;
+  left: 0;
 }
 
 .divider {

--- a/src/components/feed/StreamMetadata/StreamMetadata.css
+++ b/src/components/feed/StreamMetadata/StreamMetadata.css
@@ -29,7 +29,7 @@
 }
 
 .stream-meta-text {
-  margin-left: 8px;
+  margin-inline-start: 8px;
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added direction attribute selector to target the player control address the right and left position in rtl mode.
Update to use `margin-inline-end` so we get the margin fix for free when in rtl mode.
Update metadata text to use `margin-inline-start` to address margin when in rtl mode.

Before screenshot
<img width="1199" alt="RTL-fix-before" src="https://user-images.githubusercontent.com/37851220/220005263-34b2417d-d97c-40db-a87b-8e1fb840aabf.png">

After screenshot
<img width="1199" alt="RTL-fix-after" src="https://user-images.githubusercontent.com/37851220/220005339-9ad86dd6-3aae-471c-9d51-eecf9fc3f331.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
